### PR TITLE
debian-arm64: Use arm64v8/debian:trixie as base

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,10 +37,8 @@ jobs:
 
       - name: Build Distributions
         run: |
-            for distro in $(ls -d *-*)
-            do
-                docker build "$distro" --tag "$distro"
-            done
+          docker build --platform=linux/arm64 debian-arm64 --tag debian-arm64
+          docker build ubuntu-distro --tag ubuntu-distro
 
       - name: Push image to GitHub Container Registry
         run: |

--- a/debian-arm64/Dockerfile
+++ b/debian-arm64/Dockerfile
@@ -1,7 +1,7 @@
 # Using debian:trixie-slim as the base image
 FROM arm64v8/debian:trixie-slim
 RUN export DEBIAN_FRONTEND=noninteractive
-RUN apt-get update ; apt-get -y install net-tools git wget vim sudo zip corkscrew rsync iputils-ping locales apt-utils gpg tzdata devscripts equivs debmake
+RUN apt-get update ; apt-get -y install net-tools git wget vim sudo zip corkscrew rsync iputils-ping locales apt-utils gpg tzdata devscripts equivs debmake qt6-base-dev qt6-multimedia-dev libqt6quick6 qt6-declarative-dev cmake
 RUN locale-gen en_US en_US.UTF-8
 RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
     DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash && \


### PR DESCRIPTION
Currently, we are using arm64v8/debian:trixie-slim as the base. But this image seems to be unavailable, as a result of which our workflow is failing.

Therefore use, in its stead, arm64v8/debian:trixie. This layer seems to be available.